### PR TITLE
variable.scssの削除

### DIFF
--- a/app/assets/stylesheets/_variable.scss
+++ b/app/assets/stylesheets/_variable.scss
@@ -1,6 +1,0 @@
-$gray :#333333;
-// $white : #ffffff;
-$lightblue: #38AEF0;
-$lightgray: #999999;
-$graywhite: #fafafa;
-$derkgray: #2f3e51;


### PR DESCRIPTION
# what
　variable.scssの削除
# why
　色の変数を指定したcolor.scssと重複する部分があったため。